### PR TITLE
README Instructions for Streaming From Channel ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,29 @@ First, install docker into your system. Read about it here: https://www.docker.i
 Then just do something like this, to launch a proxy for Torrent-TV:
 
 1. Build the image.
-   
-  ```
-  docker build -t ikatson/aceproxy git://github.com/ikatson/docker-acestream-proxy.git
-  ```
+   ```
+   docker build -t ikatson/aceproxy git://github.com/ikatson/docker-acestream-proxy.git
+   ```
+   OR download the binary one, this is faster
+   ```
+   docker pull ikatson/aceproxy:latest
+   ```
 
-  OR download the binary one, this is faster
-  
-  ```
-  docker pull ikatson/aceproxy:latest
-  ```
 2. Run the TorrentTV proxy with your key.
-  
-  ```
-  docker run -t -p 8000:8000 ikatson/aceproxy
-  ```
+   ```
+   docker run -t -p 8000:8000 ikatson/aceproxy
+   ```
+
 3. Read AceProxy manual for usage instructions: https://github.com/ValdikSS/aceproxy/wiki.
+   
+   Or for the simple case of trying to load another acesteam link with the format 
+   `acestream://{channel_id}` you can use the following link:
+   
+   ```
+   http://[SERVER_IP]:8000/pid/{channel_id}/stream.mp4
+   ```
+   
+   This works as a stream in VLC or other media players.
 
 
 Usage with Torrent-TV


### PR DESCRIPTION
- added documentation for the use case of loading a stream with the format `acestream://{channel_id}`
- fixed markdown indentation/formatting in README